### PR TITLE
Revert usage of sh:prefixes

### DIFF
--- a/shapes/case-corpora.ttl
+++ b/shapes/case-corpora.ttl
@@ -22,20 +22,6 @@
 		<http://www.w3.org/ns/dcat> ,
 		<https://ontology.caseontology.org/case/case/1.0.0>
 		;
-	sh:declare
-		[
-			sh:namespace "http://example.org/ontology/case/corpora/"^^xsd:anyURI ;
-			sh:prefix "case-corpora" ;
-		] ,
-		[
-			sh:namespace "http://www.w3.org/ns/dcat#"^^xsd:anyURI ;
-			sh:prefix "dcat" ;
-		] ,
-		[
-			sh:namespace "https://ontology.unifiedcyberontology.org/uco/core/"^^xsd:anyURI ;
-			sh:prefix "uco-core" ;
-		]
-		;
 	.
 
 case-corpora:Dataset
@@ -80,11 +66,9 @@ case-corpora:Dataset
 			a sh:SPARQLConstraint ;
 			rdfs:comment "This constraint is meant to encourage usage of the case-corpora:hasDistribution property."@en ;
 			sh:message "Each dcat:distribution assignment must have a uco-core:object assignment."@en ;
-			sh:prefixes
-				<http://www.w3.org/ns/dcat#> ,
-				<https://ontology.unifiedcyberontology.org/uco/core/>
-				;
 			sh:select """
+				PREFIX dcat: <http://www.w3.org/ns/dcat#>
+				PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 				SELECT $this (dcat:distribution AS ?path) ?value
 				WHERE {
 					$this dcat:distribution ?value .
@@ -98,11 +82,9 @@ case-corpora:Dataset
 			a sh:SPARQLConstraint ;
 			rdfs:comment "This constraint is meant to encourage usage of the case-corpora:hasDistribution property."@en ;
 			sh:message "Each uco-core:object assignment must have a dcat:distribution assignment."@en ;
-			sh:prefixes
-				<http://www.w3.org/ns/dcat#> ,
-				<https://ontology.unifiedcyberontology.org/uco/core/>
-				;
 			sh:select """
+				PREFIX dcat: <http://www.w3.org/ns/dcat#>
+				PREFIX uco-core: <https://ontology.unifiedcyberontology.org/uco/core/>
 				SELECT $this (uco-core:object AS ?path) ?value
 				WHERE {
 					$this uco-core:object ?value .
@@ -220,11 +202,9 @@ dcat:Dataset
 	sh:sparql [
 		a sh:SPARQLConstraint ;
 		sh:message "Each dcat:Dataset (except the dcat:Catalog) in CASE-Corpora must have case-corpora:hasDatasetDirectory populated."@en ;
-		sh:prefixes
-			<http://example.org/ontology/case/corpora/> ,
-			<http://www.w3.org/ns/dcat#>
-			;
 		sh:select """
+			PREFIX case-corpora: <http://example.org/ontology/case/corpora/>
+			PREFIX dcat: <http://www.w3.org/ns/dcat#>
 			SELECT $this
 			WHERE {
 				FILTER NOT EXISTS {


### PR DESCRIPTION
The new typo checking feature of `case_validate` flags usage of the IRI serving as the `uco-core:` prefix as an unrecognized concept.

Rather than determine how to encode a definition for the prefix IRI within the ontology, this patch removes usage of `sh:declare`, due to downstream side-effects noted during development of UCO Issue 457.